### PR TITLE
Fix ClassCastException in getDevicePixelRatio() method

### DIFF
--- a/eyes.appium.java/src/main/java/com/applitools/eyes/appium/EyesAppiumDriver.java
+++ b/eyes.appium.java/src/main/java/com/applitools/eyes/appium/EyesAppiumDriver.java
@@ -64,7 +64,7 @@ public class EyesAppiumDriver extends EyesWebDriver {
     }
 
     public double getDevicePixelRatio () {
-        return ((Long) getCachedSessionDetails().get("pixelRatio")).doubleValue();
+        return (Double) getCachedSessionDetails().get("pixelRatio");
     }
 
     /**

--- a/eyes.appium.java/src/main/java/com/applitools/eyes/appium/EyesAppiumDriver.java
+++ b/eyes.appium.java/src/main/java/com/applitools/eyes/appium/EyesAppiumDriver.java
@@ -64,7 +64,12 @@ public class EyesAppiumDriver extends EyesWebDriver {
     }
 
     public double getDevicePixelRatio () {
-        return (Double) getCachedSessionDetails().get("pixelRatio");
+        Object pixelRatio = getCachedSessionDetails().get("pixelRatio");
+        if (pixelRatio instanceof Double) {
+            return (Double) pixelRatio;
+        } else {
+            return ((Long) pixelRatio).doubleValue();
+        }
     }
 
     /**


### PR DESCRIPTION
Do not need cast to Long because the value is already Double