### PR TITLE
Bugfix trello 1670 array out of bounds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+
+### Fixed
+- Check for XCUIElementTypeTable child count to avoid IndexOfBoundException. [Trello 1670](https://trello.com/c/If5sMKeW)
+
 ## [4.6.0] - 2020-03-24
 ### Fixed
 - Correct element location and size when using layout(), ignore(), strict(), content(), floating() and accessibility(). [Trello 1601](https://trello.com/c/mN1R9zVZ)

--- a/eyes.appium.java/src/main/java/com/applitools/eyes/appium/IOSScrollPositionProvider.java
+++ b/eyes.appium.java/src/main/java/com/applitools/eyes/appium/IOSScrollPositionProvider.java
@@ -175,8 +175,12 @@ public class IOSScrollPositionProvider extends AppiumScrollPositionProvider {
                 try {
                     contentSize = EyesAppiumUtils.getContentSize(driver, activeScroll);
                     List<WebElement> list = activeScroll.findElements(MobileBy.xpath("//XCUIElementTypeTable[1]/*"));
-                    WebElement lastElement = list.get(list.size()-1);
-                    contentSize.scrollableOffset = lastElement.getLocation().getY() + lastElement.getSize().getHeight();
+                    if (!list.isEmpty()) {
+                        WebElement lastElement = list.get(list.size()-1);
+                        contentSize.scrollableOffset = lastElement.getLocation().getY() + lastElement.getSize().getHeight();
+                    } else {
+                        logger.verbose("XCUIElementTypeTable does not have child...");
+                    }
                     logger.verbose("Retrieved contentSize, it is: " + contentSize);
                 } catch (IOException e) {
                     logger.log("WARNING: could not retrieve content size from active scroll element");


### PR DESCRIPTION
Check for XCUIElementTypeTable child count to avoid ArrayIndexOutOfBoundsException