### PR TITLE
Bugfix trello 1663 webview fullpage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 
 ### Fixed 
 - Reset contentSize if no active scrollable element. [Trello 1371](https://trello.com/c/M90Imf7t) 
+- WebView full page screenshot with `com.applitools.eyes.selenium.Eyes`. [Trello 1663](https://trello.com/c/HnJKeNKO)
+- Getting device pixel ratio for `com.applitools.eyes.selenium.Eyes`.
 
 ## [4.7.0] - 2020-04-03
 ### Fixed

--- a/eyes.sdk.core/src/main/java/com/applitools/eyes/OSNames.java
+++ b/eyes.sdk.core/src/main/java/com/applitools/eyes/OSNames.java
@@ -7,5 +7,6 @@ public class OSNames {
     public final static String IOS = "IOS";
     public final static String Macintosh = "Macintosh";
     public final static String ChromeOS = "ChromeOS";
+    public static final String ANDROID = "Android";
 
 }

--- a/eyes.selenium.java/src/main/java/com/applitools/eyes/selenium/Eyes.java
+++ b/eyes.selenium.java/src/main/java/com/applitools/eyes/selenium/Eyes.java
@@ -356,6 +356,8 @@ public class Eyes extends EyesBase {
 
         initDriver(driver);
 
+        setJsExecutor(new SeleniumJavaScriptExecutor(getEyesDriver()));
+
         tryUpdateDevicePixelRatio();
 
         screenshotFactory = new EyesWebDriverScreenshotFactory(logger, getEyesDriver());
@@ -371,8 +373,6 @@ public class Eyes extends EyesBase {
                 this, logger);
 
         initDriverBasedPositionProviders();
-
-        setJsExecutor(new SeleniumJavaScriptExecutor(getEyesDriver()));
 
         getEyesDriver().setRotation(getRotation());
         return getEyesDriver();

--- a/eyes.selenium.java/src/main/java/com/applitools/eyes/selenium/EyesSeleniumUtils.java
+++ b/eyes.selenium.java/src/main/java/com/applitools/eyes/selenium/EyesSeleniumUtils.java
@@ -208,7 +208,7 @@ public class EyesSeleniumUtils {
      */
     public static void setCurrentScrollPosition(IEyesJsExecutor executor,
                                                 Location location) {
-        executor.executeScript(String.format("window.scrollTo(%d,%d)",
+        executor.executeScript(String.format("window.scroll(%d,%d)",
                 location.getX(), location.getY()));
     }
 

--- a/eyes.selenium.java/src/main/java/com/applitools/eyes/selenium/capture/ImageProviderFactory.java
+++ b/eyes.selenium.java/src/main/java/com/applitools/eyes/selenium/capture/ImageProviderFactory.java
@@ -2,6 +2,7 @@ package com.applitools.eyes.selenium.capture;
 
 import com.applitools.eyes.BrowserNames;
 import com.applitools.eyes.Logger;
+import com.applitools.eyes.OSNames;
 import com.applitools.eyes.UserAgent;
 import com.applitools.eyes.capture.ImageProvider;
 import com.applitools.eyes.selenium.Eyes;
@@ -21,6 +22,8 @@ public class ImageProviderFactory {
                 }
             } else if (ua.getBrowser().equals(BrowserNames.Safari)) {
                 return new SafariScreenshotImageProvider(eyes, logger, tsInstance, ua);
+            } else if (ua.getOS().equals(OSNames.ANDROID) || ua.getOS().equals(OSNames.IOS)) {
+                return new MobileViewportScreenshotImageProvider(logger, eyes.getEyesDriver());
             }
         }
         return new TakesScreenshotImageProvider(logger, tsInstance);

--- a/eyes.selenium.java/src/main/java/com/applitools/eyes/selenium/capture/MobileViewportScreenshotImageProvider.java
+++ b/eyes.selenium.java/src/main/java/com/applitools/eyes/selenium/capture/MobileViewportScreenshotImageProvider.java
@@ -1,0 +1,28 @@
+package com.applitools.eyes.selenium.capture;
+
+import com.applitools.eyes.Logger;
+import com.applitools.eyes.capture.ImageProvider;
+import com.applitools.utils.ImageUtils;
+import org.openqa.selenium.JavascriptExecutor;
+import org.openqa.selenium.WebDriver;
+
+import java.awt.image.BufferedImage;
+
+public class MobileViewportScreenshotImageProvider implements ImageProvider {
+
+    private final Logger logger;
+    private final WebDriver driver;
+
+    public MobileViewportScreenshotImageProvider(Logger logger, WebDriver driver) {
+        this.logger = logger;
+        this.driver = driver;
+    }
+
+    @Override
+    public BufferedImage getImage() {
+        logger.verbose("Getting screenshot as base64...");
+        String screenshot64 = (String) ((JavascriptExecutor)driver).executeScript("mobile: viewportScreenshot");
+        logger.verbose("Done getting base64! Creating BufferedImage...");
+        return ImageUtils.imageFromBase64(screenshot64);
+    }
+}


### PR DESCRIPTION
Fixed fullpage screenshot taking from WebView via ..selenium.Eyes
* Created MobileViewportScreenshotImageProvider to take a viewport screenshot without status bar
* Fixed getting device pixel ratio in ..selenium.Eyes
* Using `window.scroll` instead of `window.scrollTo` for setCurrentScrollPosition