### PR TITLE
Rfe trello 1756 eyes date header in every request

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 
 ### Updated
 - Send DOM directly to Azure Storage server. [Trello 1743](https://trello.com/c/PVyhBHCh)
+### Added
+- Eyes-Date header for all requests in the long-running task process. [Trello 1756](https://trello.com/c/zqcGscs3)
 
 ## [4.10.0] - 2020-04-16
 ### Updated

--- a/eyes.connectivity.java.jboss/src/main/java/com/applitools/eyes/RestClient.java
+++ b/eyes.connectivity.java.jboss/src/main/java/com/applitools/eyes/RestClient.java
@@ -292,6 +292,8 @@ public class RestClient {
     protected Response sendHttpWebRequest(String path, final String method, String accept) {
         // Building the request
         Invocation.Builder invocationBuilder = restClient.target(path).request(accept);
+        String currentTime = GeneralUtils.toRfc1123(Calendar.getInstance(TimeZone.getTimeZone("UTC")));
+        invocationBuilder.header("Eyes-Date", currentTime);
 
         // Actually perform the method call and return the result
         return invocationBuilder.method(method);

--- a/eyes.connectivity.java.jersey1x/src/main/java/com/applitools/eyes/RestClient.java
+++ b/eyes.connectivity.java.jersey1x/src/main/java/com/applitools/eyes/RestClient.java
@@ -267,6 +267,8 @@ public class RestClient {
     protected ClientResponse sendHttpWebRequest(String path, final String method, String accept) {
         // Building the request
         WebResource.Builder invocationBuilder = restClient.resource(path).accept(accept);
+        String currentTime = GeneralUtils.toRfc1123(Calendar.getInstance(TimeZone.getTimeZone("UTC")));
+        invocationBuilder.header("Eyes-Date", currentTime);
 
         // Actually perform the method call and return the result
         return invocationBuilder.method(method, ClientResponse.class);

--- a/eyes.connectivity.java.jersey2x/src/main/java/com/applitools/eyes/RestClient.java
+++ b/eyes.connectivity.java.jersey2x/src/main/java/com/applitools/eyes/RestClient.java
@@ -255,6 +255,8 @@ public class RestClient {
     protected Response sendHttpWebRequest(String path, final String method, String accept) {
         // Building the request
         Invocation.Builder invocationBuilder = restClient.target(path).request(accept);
+        String currentTime = GeneralUtils.toRfc1123(Calendar.getInstance(TimeZone.getTimeZone("UTC")));
+        invocationBuilder.header("Eyes-Date", currentTime);
 
         // Actually perform the method call and return the result
         return invocationBuilder.method(method);


### PR DESCRIPTION
Eyes-Date header for all requests in the long-running task process