### PR TITLE
Add mobile native on saucelabs tests

### DIFF
--- a/eyes.appium.java/src/main/java/com/applitools/eyes/appium/EyesAppiumDriver.java
+++ b/eyes.appium.java/src/main/java/com/applitools/eyes/appium/EyesAppiumDriver.java
@@ -55,15 +55,26 @@ public class EyesAppiumDriver extends EyesWebDriver {
     }
 
     public HashMap<String, Integer> getViewportRect () {
+
         Map<String, Long> rectMap = (Map<String, Long>) getCachedSessionDetails().get("viewportRect");
         HashMap<String, Integer> intRectMap = new HashMap<String, Integer>();
-        intRectMap.put("width", rectMap.get("width").intValue());
-        intRectMap.put("height", rectMap.get("height").intValue());
+        if (EyesAppiumUtils.isRunOnTestCloud(driver)) {
+            Dimension viewportSize = driver.manage().window().getSize();
+            intRectMap.put("width", viewportSize.width);
+            intRectMap.put("height", viewportSize.height);
+        }
+        else {
+            intRectMap.put("width", rectMap.get("width").intValue());
+            intRectMap.put("height", rectMap.get("height").intValue());
+        }
         return intRectMap;
     }
 
     public int getStatusBarHeight() {
         Object statusBarHeight = getCachedSessionDetails().get("statBarHeight");
+        if (EyesAppiumUtils.isRunOnTestCloud(driver)) {
+            statusBarHeight = 0.0;
+        }
         if (statusBarHeight instanceof Double) {
             return ((Double) statusBarHeight).intValue();
         } else {
@@ -73,6 +84,9 @@ public class EyesAppiumDriver extends EyesWebDriver {
 
     public double getDevicePixelRatio () {
         Object pixelRatio = getCachedSessionDetails().get("pixelRatio");
+        if (EyesAppiumUtils.isRunOnTestCloud(driver)) {
+            return 1.0;
+        }
         if (pixelRatio instanceof Double) {
             return (Double) pixelRatio;
         } else {

--- a/eyes.appium.java/src/main/java/com/applitools/eyes/appium/EyesAppiumUtils.java
+++ b/eyes.appium.java/src/main/java/com/applitools/eyes/appium/EyesAppiumUtils.java
@@ -25,6 +25,7 @@ import org.openqa.selenium.remote.RemoteWebElement;
 public class EyesAppiumUtils extends EyesSeleniumUtils{
 
     private static final String NATIVE_APP = "NATIVE_APP";
+    private static final String TEST_CLOUD = "saucelabs";
 
     private static String SCROLLVIEW_XPATH = "//*[@scrollable='true']";
     private static String FIRST_VIS_XPATH = "/*[@firstVisible='true']";
@@ -57,6 +58,20 @@ public class EyesAppiumUtils extends EyesSeleniumUtils{
     public static boolean isIOS(WebDriver driver) {
         driver = getUnderlyingDriver(driver);
         return driver instanceof IOSDriver;
+    }
+
+    /**
+     * @param driver The driver to test.
+     * @return {@code true} if the driver address is an test cloud address (saucelabs or browserstack - defined in const above).
+     * {@code false} otherwise.
+     */
+    public static boolean isRunOnTestCloud(WebDriver driver) {
+        if (!isMobileDevice(driver)) {
+            return false;
+        }
+        else{
+            return ((AppiumDriver) driver).getRemoteAddress().getHost().toLowerCase().contains(TEST_CLOUD);
+        }
     }
 
     /**

--- a/eyes.appium.java/src/main/java/com/applitools/eyes/appium/capture/ImageProviderFactory.java
+++ b/eyes.appium.java/src/main/java/com/applitools/eyes/appium/capture/ImageProviderFactory.java
@@ -11,7 +11,7 @@ import org.openqa.selenium.WebDriver;
 public class ImageProviderFactory {
     public static ImageProvider getImageProvider(Eyes eyes, Logger logger, WebDriver driver, boolean viewportImage) {
         if (viewportImage) {
-            return new MobileViewportScreenshotImageProvider(logger, (JavascriptExecutor) driver);
+            return new MobileViewportScreenshotImageProvider(logger, driver);
         }
         return new TakesScreenshotImageProvider(logger, (TakesScreenshot) driver);
     }

--- a/eyes.appium.java/src/main/java/com/applitools/eyes/appium/capture/MobileViewportScreenshotImageProvider.java
+++ b/eyes.appium.java/src/main/java/com/applitools/eyes/appium/capture/MobileViewportScreenshotImageProvider.java
@@ -1,9 +1,14 @@
 package com.applitools.eyes.appium.capture;
 
 import com.applitools.eyes.Logger;
+import com.applitools.eyes.appium.EyesAppiumDriver;
+import com.applitools.eyes.appium.EyesAppiumUtils;
 import com.applitools.eyes.capture.ImageProvider;
 import com.applitools.utils.ImageUtils;
 import org.openqa.selenium.JavascriptExecutor;
+import org.openqa.selenium.OutputType;
+import org.openqa.selenium.TakesScreenshot;
+import org.openqa.selenium.WebDriver;
 
 import java.awt.image.BufferedImage;
 
@@ -14,16 +19,26 @@ public class MobileViewportScreenshotImageProvider implements ImageProvider {
 
     private final Logger logger;
     private final JavascriptExecutor jsExecutor;
+    private final TakesScreenshot tsInstance;
+    private final Boolean isRunOnTestCloud;
 
-    public MobileViewportScreenshotImageProvider(Logger logger, JavascriptExecutor jsExecutor) {
+    public MobileViewportScreenshotImageProvider(Logger logger, WebDriver driver) {
         this.logger = logger;
-        this.jsExecutor = jsExecutor;
+        this.jsExecutor = (JavascriptExecutor) driver;
+        this.tsInstance = (TakesScreenshot) driver;
+        this.isRunOnTestCloud = (EyesAppiumUtils.isRunOnTestCloud(((EyesAppiumDriver)driver).getRemoteWebDriver()));
     }
 
     @Override
     public BufferedImage getImage() {
+        String screenshot64;
         logger.verbose("Getting screenshot as base64...");
-        String screenshot64 = (String) jsExecutor.executeScript("mobile: viewportScreenshot");
+        if (isRunOnTestCloud) {
+            screenshot64 = tsInstance.getScreenshotAs(OutputType.BASE64);
+        }
+        else{
+            screenshot64 = (String) jsExecutor.executeScript("mobile: viewportScreenshot");
+        }
         logger.verbose("Done getting base64! Creating BufferedImage...");
         return ImageUtils.imageFromBase64(screenshot64);
     }

--- a/eyes.appium.java/src/test/java/com/applitools/eyes/appium/MobileNativeSauceLabsTests.java
+++ b/eyes.appium.java/src/test/java/com/applitools/eyes/appium/MobileNativeSauceLabsTests.java
@@ -1,0 +1,120 @@
+package com.applitools.eyes.appium;
+
+import com.applitools.eyes.BatchInfo;
+import com.applitools.eyes.Region;
+import com.applitools.eyes.fluent.ICheckSettings;
+import com.applitools.eyes.selenium.fluent.Target;
+import io.appium.java_client.android.AndroidDriver;
+import io.appium.java_client.ios.IOSDriver;
+import org.openqa.selenium.WebDriver;
+import org.openqa.selenium.remote.DesiredCapabilities;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+import java.net.URL;
+
+public class MobileNativeSauceLabsTests {
+
+    public final static String SAUCE_USERNAME = System.getenv("SAUCE_USERNAME");
+    public final static String SAUCE_ACCESS_KEY = System.getenv("SAUCE_ACCESS_KEY");
+    public final static String SAUCE_SELENIUM_URL = "https://ondemand.saucelabs.com/wd/hub";
+    private Eyes eyes;
+
+    @BeforeMethod
+    public void SetupTest()
+    {
+        eyes = new Eyes();
+        eyes.setBatch(new BatchInfo("Java4 Appium Mobile Native Tests"));
+    }
+
+    @Test
+    public void AndroidNativeAppWindowTest() throws Exception {
+        WebDriver driver = new AndroidDriver(new URL(SAUCE_SELENIUM_URL), getAndroidCapabilities());
+        try {
+            eyes.open(driver, "AndroidNativeApp", "AndroidNativeApp checkWindow");
+            eyes.check("Contact list", com.applitools.eyes.selenium.fluent.Target.window().ignore(new Region(0,0,1440,100)));
+            eyes.close();
+        } finally {
+            driver.quit();
+            eyes.abortIfNotClosed();
+        }
+    }
+
+    @Test
+    public void AndroidNativeAppRegionTest() throws Exception {
+        WebDriver driver = new AndroidDriver(new URL(SAUCE_SELENIUM_URL), getAndroidCapabilities());
+        try {
+            eyes.open(driver, "AndroidNativeApp", "AndroidNativeApp checkRegionFloating");
+            ICheckSettings settings = com.applitools.eyes.selenium.fluent.Target.region(new Region(0, 100, 1400, 2000))
+                    .floating(new Region(10, 10, 20, 20), 3, 3, 20, 30);
+            eyes.check("Contact list - Region with floating region", settings);
+            eyes.close();
+        } finally {
+            driver.quit();
+            eyes.abortIfNotClosed();
+        }
+    }
+
+    @Test
+    public void iOSNativeAppTest() throws Exception {
+        WebDriver driver = null;
+        try {
+            driver = new IOSDriver(new URL(SAUCE_SELENIUM_URL), getIOSCapabilities());
+            eyes.open(driver, "iOSNativeApp", "iOSNativeApp checkWindow");
+            eyes.check("checkWindow", com.applitools.eyes.selenium.fluent.Target.window().ignore(new Region(0,0,300,100)));
+            eyes.close();
+        } finally {
+            if (driver != null) {
+                driver.quit();
+            }
+            eyes.abortIfNotClosed();
+        }
+    }
+
+    @Test
+    public void iOSNativeAppRegionTest() throws Exception {
+        WebDriver driver = null;
+        try {
+            driver = new IOSDriver(new URL(SAUCE_SELENIUM_URL), getIOSCapabilities());
+            eyes.open(driver, "iOSNativeApp", "iOSNativeApp checkRegionFloating");
+            ICheckSettings settings = Target.region(new Region(0, 100, 375, 712))
+                    .floating(new Region(10, 10, 20, 20), 3, 3, 20, 30);
+            eyes.check("Fluent - Window with floating region", settings);
+            eyes.close();
+        } finally {
+            if (driver != null) {
+                driver.quit();
+            }
+            eyes.abortIfNotClosed();
+        }
+    }
+
+    private DesiredCapabilities getAndroidCapabilities() {
+        DesiredCapabilities capabilities = new DesiredCapabilities();
+        capabilities.setCapability("platformName", "Android");
+        capabilities.setCapability("deviceName", "Samsung Galaxy S9 WQHD GoogleAPI Emulator");
+        capabilities.setCapability("platformVersion", "8.1");
+        capabilities.setCapability("app", "http://saucelabs.com/example_files/ContactManager.apk");
+        capabilities.setCapability("clearSystemFiles", true);
+        capabilities.setCapability("noReset", true);
+        capabilities.setCapability("username", SAUCE_USERNAME);
+        capabilities.setCapability("accesskey", SAUCE_ACCESS_KEY);
+        return capabilities;
+    }
+
+    private DesiredCapabilities getIOSCapabilities() {
+        DesiredCapabilities capabilities = DesiredCapabilities.iphone();
+        capabilities.setCapability("deviceName","iPhone XS Simulator");
+        capabilities.setCapability("platformVersion", "12.2");
+        capabilities.setCapability("platformName", "iOS");
+        capabilities.setCapability("app", "https://applitools.bintray.com/Examples/HelloWorldiOS_1_0.zip");
+        capabilities.setCapability("clearSystemFiles", true);
+        capabilities.setCapability("noReset", true);
+        capabilities.setCapability("NATIVE_APP", true);
+        capabilities.setCapability("browserName", "");
+        capabilities.setCapability("name", "iOSNativeApp checkWindow");
+        capabilities.setCapability("username", SAUCE_USERNAME);
+        capabilities.setCapability("accesskey", SAUCE_ACCESS_KEY);
+        return capabilities;
+    }
+}


### PR DESCRIPTION
Add Mobile Native SauceLabs tests:
1. Test checkWindow for Android device
2. Test checkRegion+FloatingRegions for Android device
3. Test checkWindow for iOS device
4. Test checkRegion+FloatingRegions for iOS device
Uupdate SDK for these tests - add logic to define is test on SauceLabs and updates are used for this condition only