### PR TITLE
Bugfix trello 1419 incorrect fullpage on ios

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 - Send DOM directly to Azure Storage server. [Trello 1743](https://trello.com/c/PVyhBHCh)
 ### Added
 - Eyes-Date header for all requests in the long-running task process. [Trello 1756](https://trello.com/c/zqcGscs3)
+### Fixed
+- Taking IOS fullpage screenshot with elements below scrollable view. [Trello 1419](https://trello.com/c/IIIKosP8)
 
 ## [4.10.0] - 2020-04-16
 ### Updated

--- a/eyes.appium.java/src/main/java/com/applitools/eyes/appium/AppiumFullPageCaptureAlgorithm.java
+++ b/eyes.appium.java/src/main/java/com/applitools/eyes/appium/AppiumFullPageCaptureAlgorithm.java
@@ -144,6 +144,21 @@ public class AppiumFullPageCaptureAlgorithm {
         }
         while (true);
 
+        // We should check if there any elements below the scrollable view
+        // and add them to entire screenshot
+        int capturedHeight = scrollViewRegion.getHeight() + scrollViewRegion.getTop();
+        if (initialPartSize.getHeight() - capturedHeight > 0) {
+            Region partRegion = new Region(0,
+                    capturedHeight,
+                    initialPartSize.getWidth(),
+                    initialPartSize.getHeight() - capturedHeight);
+
+            currentPosition = new Location(currentPosition.getX(), lastSuccessfulLocation.getY() + lastSuccessfulPartSize.getHeight());
+
+            lastSuccessfulPartSize = captureAndStitchCurrentPart(partRegion, partRegion);
+            lastSuccessfulLocation = currentPosition;
+        }
+
         cleanupStitch(originalStitchedState, lastSuccessfulLocation, lastSuccessfulPartSize, entireSize);
         moveToTopLeft();
     }


### PR DESCRIPTION
Taking IOS fullpage screenshot with elements below scrollable view.
* Added check for remaining height below the scrollable view